### PR TITLE
fix...: skip MinKNOW cert verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minknow-api-rust"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license-file = "LICENSE.txt"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use hyper::{
 
 use hyper_openssl::HttpsConnector;
 use openssl::{
-    ssl::{SslConnector, SslMethod},
+    ssl::{SslConnector, SslMethod, SslVerifyMode},
     x509::X509,
 };
 
@@ -113,7 +113,7 @@ impl MinKNOWChannel {
 
         let mut https = HttpsConnector::with_connector(http, connector)?;
         https.set_callback(|c, _| {
-            c.set_verify_hostname(false);
+            c.set_verify(SslVerifyMode::NONE);
             Ok(())
         });
 
@@ -440,7 +440,7 @@ impl Manager {
         let response = match client.create_developer_api_token(request).await {
             Ok(response) => response.into_inner(),
             Err(err) => {
-                println!("{:?}", err);
+                println!("ERROR: {:?}", err);
                 return Err(Status::unavailable("Not available"));
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,7 @@ impl Manager {
         let response = match client.create_developer_api_token(request).await {
             Ok(response) => response.into_inner(),
             Err(err) => {
-                println!("ERROR: {:?}", err);
+                println!("{:?}", err);
                 return Err(Status::unavailable("Not available"));
             }
         };


### PR DESCRIPTION
## Summary

* A recent release of `hyper-openssl` (or more likely one of its dependencies), now fails when trying to verify the CA certificate provided by ONT (as part of MinKNOW installation) for connecting to the MinKNOW server. The failure is due to this certificate being self-signed and using an old signing algorithm. For the time being, the client will perform no certificate verification at all and the server is fine with this.
* Bumps patch version

### Testing

* All existing integration tests which interface with MinKNOW to simulate/emulate sequencers passing